### PR TITLE
Use hostPlatform system in overlay packages

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -1,7 +1,7 @@
 { kubectl-check, boda, ... }:
 final: prev:
 let
-  system = prev.stdenv.hostPlatform.system;
+  system = final.stdenv.hostPlatform.system;
 in
 {
   beleap-utils = import ./beleap-utils prev;


### PR DESCRIPTION
## Summary
- replace deprecated `system` attribute usage in overlay with `stdenv.hostPlatform.system`
- reuse computed system value when selecting overlay packages


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933acb39e488324b3f74a6edffe653a)