### PR TITLE
Configure jujutsu origin auto-track-bookmarks

### DIFF
--- a/home/programs/jujutsu/default.nix
+++ b/home/programs/jujutsu/default.nix
@@ -26,6 +26,11 @@
           "@-"
         ];
       };
+      remotes = {
+        origin = {
+          "auto-track-bookmarks" = "glob:*";
+        };
+      };
     };
   };
 }


### PR DESCRIPTION
## Summary
- configure the jujutsu origin remote to auto-track all bookmarks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933af4d511483249ece4bf95ede4552)