### PR TITLE
Route Chrome windows to workspace 2 in Aerospace

### DIFF
--- a/home/programs/aerospace/default.nix
+++ b/home/programs/aerospace/default.nix
@@ -84,6 +84,13 @@
         {
           check-further-callbacks = false;
           "if" = {
+            app-id = "com.google.Chrome";
+          };
+          run = [ "move-node-to-workspace 2" ];
+        }
+        {
+          check-further-callbacks = false;
+          "if" = {
             window-title-regex-substring = "1Password";
           };
           run = [ "layout floating" ];


### PR DESCRIPTION
### Motivation
- Ensure Chrome windows are automatically moved to Aerospace workspace 2 to match existing browser routing behavior.
- Keep workspace routing consistent for other apps already configured (e.g., Firefox, WezTerm).
- Introduce a small behavioral configuration change to the Aerospace window-detection rules.

### Description
- Updated the Aerospace configuration file at `home/programs/aerospace/default.nix`.
- Added an `on-window-detected` rule with `app-id = "com.google.Chrome"` and `run = [ "move-node-to-workspace 2" ]`.
- Placed the Chrome rule alongside the existing browser rule for `org.mozilla.firefoxdeveloperedition` so browser windows are routed to the same workspace.
- The rule uses `check-further-callbacks = false` to stop further matching after routing Chrome.

### Testing
- No automated tests were run because this is a configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69489e37a7e08324aec9dbc727ca8281)