### PR TITLE
Add result to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 nixos.qcow2
+result


### PR DESCRIPTION
### Motivation

- Prevent accidental commits of the build output symlink `result` into the repository.
- Avoid polluting the repo with generated artifacts similar to the existing `nixos.qcow2` ignore.
- This is a structural (tidy) change that does not modify runtime behavior.

### Description

- Added a `result` line to `.gitignore`.
- Committed the change with message `structural: ignore result symlink`.
- No source code or configuration behavior was modified.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948ad074b588324a74b29d29ca2287f)