### PR TITLE
Extract mac-app-util modules into dedicated module file

### DIFF
--- a/modules/mac-app-utils/default.nix
+++ b/modules/mac-app-utils/default.nix
@@ -1,0 +1,14 @@
+{
+  lib,
+  mac-app-util,
+  metadata,
+  ...
+}:
+lib.optionals (metadata.os == "darwin") [
+  mac-app-util.darwinModules.default
+  {
+    home-manager.sharedModules = [
+      mac-app-util.homeManagerModules.default
+    ];
+  }
+]


### PR DESCRIPTION
### Motivation
- Keep darwin-specific `mac-app-util` wiring out of `mkSystem.nix` so the main module list stays concise and static.
- Allow `mac-app-util` to export a list of modules (rather than being inlined) so these can be merged cleanly into the global `modules` list.
- Ensure modules can access required flake inputs via `specialArgs` without additional ad-hoc wiring.

### Description
- Added `modules/mac-app-utils/default.nix` which returns the darwin-only `mac-app-util` modules and the `home-manager.sharedModules` entry as an optional list.
- Included `./modules/mac-app-utils` in the `modules` list in `mkSystem.nix` and removed the previous inline `lib.optionals` block for `mac-app-util`.
- Simplified the `modules` construction by using a static nested list and `lib.flatten` instead of dynamic `map`/`callPackage`/debug tracing.
- Exposed `nixpkgs-unstable`, `beleap-overlay`, `kubectl-check`, and `boda` via `specialArgs` in `mkSystem.nix` so modules can reference those inputs.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f941a74e08324ab797ce0014a8c39)