### PR TITLE
Add pgcli and mycli to common home packages

### DIFF
--- a/home/common.nix
+++ b/home/common.nix
@@ -38,6 +38,8 @@
       coreutils-full
       gtrash
       dive
+      pgcli
+      mycli
     ]
     ++ (lib.optionals (metadata.kind == "personal") [
       pkgs._1password-cli


### PR DESCRIPTION
### Motivation
- Provide interactive database CLIs by adding `pgcli` and `mycli` to the shared Home Manager package set.
- Ensure these tools are available across user profiles that include the common configuration.

### Description
- Added `pgcli` and `mycli` to the `home.packages` list in `home/common.nix`.
- This is a behavioral change that installs the two tools into the common Home Manager environment.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69536c27641083249f8721766de7aabb)