### PR TITLE
Add fzf-make to home packages

### DIFF
--- a/home/common.nix
+++ b/home/common.nix
@@ -27,6 +27,7 @@
       gnupg
       oauth2c
       curl
+      fzf-make
       boda
       ghc
       yaml-language-server


### PR DESCRIPTION
### Motivation
- Make the `fzf-make` utility available in the configured home environment by including it in the global package list.
- This is a behavioral change to enable an additional user-facing tool across systems managed by the configuration.

### Description
- Updated `home/common.nix` to add `fzf-make` to the `home.packages` list.
- The change is a single-line addition and categorized as a behavioral change in the commit message (`behavioral: add fzf-make package`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b0b4ffb98832485e58a71d56a7ba4)