### PR TITLE
Replace tldr with tealdeer

### DIFF
--- a/config/recipe/base/default.nix
+++ b/config/recipe/base/default.nix
@@ -24,7 +24,7 @@ _: {
     { pkgs, ... }:
     {
       home.packages = with pkgs; [
-        tldr
+        tealdeer
       ];
     };
 }


### PR DESCRIPTION
### Motivation
- Replace the `tldr` package with the maintained `tealdeer` alternative in the base home package list.
- Provide a modern CLI cheat-sheet tool by default in the base recipe.
- Keep the change small and focused on user tooling provided by the `hm` profile.

### Description
- Update `config/recipe/base/default.nix` to replace `tldr` with `tealdeer` in the `hm.home.packages` list.
- No other configuration or package lists were modified.
- The change is behavioral and limited to the base recipe package set.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c6a7216cc83248eea0fd15bca4c6e)