### PR TITLE
Enable tealdeer in home-manager with rustls backend

### DIFF
--- a/config/recipe/base/default.nix
+++ b/config/recipe/base/default.nix
@@ -23,8 +23,11 @@ _: {
   hm =
     { pkgs, ... }:
     {
-      home.packages = with pkgs; [
-        tealdeer
-      ];
+      programs.tealdeer = {
+        enable = true;
+        settings = {
+          tls_backend = "rustls-with-native-roots";
+        };
+      };
     };
 }


### PR DESCRIPTION
### Motivation
- Move `tealdeer` from a system package to Home Manager so it is managed per-user via `programs.tealdeer`.
- Ensure tealdeer uses a reliable TLS stack by setting `tls_backend` to `rustls-with-native-roots`.
- Keep system packages list focused on solely system-level tools and delegate user tooling to Home Manager.

### Description
- Removed `tealdeer` from `home.packages` in `config/recipe/base/default.nix`.
- Added `programs.tealdeer.enable = true;` and `programs.tealdeer.settings.tls_backend = "rustls-with-native-roots";` in `config/recipe/base/default.nix`.
- Updated and committed the configuration change to the repository.

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c6edab7fc8324a0c981fe9d29b73a)