### PR TITLE
Remove tealdeer TLS backend setting

### DIFF
--- a/config/recipe/base/default.nix
+++ b/config/recipe/base/default.nix
@@ -25,11 +25,6 @@ _: {
     {
       programs.tealdeer = {
         enable = true;
-        settings = {
-          updates = {
-            tls_backend = "rustls-with-native-roots";
-          };
-        };
       };
     };
 }


### PR DESCRIPTION
### Motivation
- Remove an explicit TLS backend override for `tealdeer` in the base home-manager recipe to avoid forcing a specific TLS implementation.
- The previous setting `tls_backend = "rustls-with-native-roots";` was considered unnecessary at this layer of configuration.

### Description
- Deleted the `settings.updates.tls_backend` block under `programs.tealdeer` in `config/recipe/base/default.nix`.
- Left `programs.tealdeer.enable = true;` intact and made no other configuration changes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ef9429c148324997bd68c39b84cac)