### PR TITLE
Add GitHub Actions workflow to build NixOS and Darwin configs

### DIFF
--- a/.github/workflows/build-configs.yml
+++ b/.github/workflows/build-configs.yml
@@ -34,6 +34,8 @@ jobs:
           mkdir -p artifacts
 
           targets=(
+            "nixos:vm-arm64-Darwin-personal:nixosConfigurations.vm-arm64-Darwin-personal.config.system.build.toplevel"
+            "nixos:vm-arm64-Darwin-work:nixosConfigurations.vm-arm64-Darwin-work.config.system.build.toplevel"
             "darwin:beleap-m1air:darwinConfigurations.beleap-m1air.system"
             "darwin:csjang-m3pro:darwinConfigurations.csjang-m3pro.system"
           )


### PR DESCRIPTION
### Motivation
- Run and verify NixOS and macOS (nix-darwin) configuration builds in CI for pull requests and pushes.
- Provide immediate feedback on build success or failure by commenting on PRs or commits with results.
- Capture failure logs and a diff summary to help diagnose build regressions quickly.

### Description
- Added `.github/workflows/build-configs.yml` which provisions Nix (`cachix/install-nix-action@v30`) with flakes enabled and runs on `pull_request` and `push` events.
- The workflow defines a list of configuration targets and iterates them, running `nix build` for each attribute while writing logs to an `artifacts` directory.
- It produces a `build-summary.md` containing per-target success/failure, the last 200 lines of failing logs, and a diff summary, then posts that text as a comment using `actions/github-script@v7`.
- The job sets `status` via `GITHUB_OUTPUT` and fails the workflow if any target build fails.

### Testing
- No automated tests were executed for this workflow change; the workflow will run automatically on the next `push` or `pull_request` event.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fbd71dd5883248ca0ea652eabcbef)