### PR TITLE
Create macOS nixpkgs config and enable Android SDK license

### DIFF
--- a/config/recipe/nix/default.nix
+++ b/config/recipe/nix/default.nix
@@ -6,6 +6,7 @@
 
       nixpkgs = {
         config.allowUnfree = true;
+        config.android_sdk.accept_license = true;
       };
 
       # Necessary for using flakes on this system.

--- a/home/macos.nix
+++ b/home/macos.nix
@@ -22,4 +22,11 @@
     ++ (lib.optionals (metadata.kind == "work") [ ]);
 
   home.homeDirectory = "/Users/${metadata.usernameLower}";
+
+  home.file.".config/nixpkgs/config.nix".text = ''
+    {
+      allowUnfree = true;
+      android_sdk.accept_license = true;
+    }
+  '';
 }


### PR DESCRIPTION
### Motivation
- Accept the Android SDK license so Android tooling and unfree packages work on macOS `nix-darwin` homes.
- The system `nixpkgs` already set unfree, but users reported that `~/.config/nixpkgs/config.nix` did not exist so the per-user setting was missing.
- Ensure both system-level and per-user nixpkgs configurations explicitly enable the Android SDK license and allow unfree packages.

### Description
- Add `config.android_sdk.accept_license = true;` to the `nixpkgs` block in `config/recipe/nix/default.nix`.
- Create `~/.config/nixpkgs/config.nix` via `home.file` in `home/macos.nix` containing `allowUnfree = true;` and `android_sdk.accept_license = true;`.
- Scope the change to macOS home-manager files so per-user config is created for `nix-darwin` homes.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69628ce4760c83248b761094aabc3723)