### PR TITLE
Add GitHub Actions matrix to build flake outputs and post failure logs

### DIFF
--- a/.github/workflows/build-flake.yml
+++ b/.github/workflows/build-flake.yml
@@ -15,15 +15,19 @@ jobs:
           - name: nixos-vm-arm64-Darwin-personal
             runner: ubuntu-latest
             flake_attr: .#nixosConfigurations.vm-arm64-Darwin-personal.config.system.build.toplevel
+            install_options: ""
           - name: nixos-vm-arm64-Darwin-work
             runner: ubuntu-latest
             flake_attr: .#nixosConfigurations.vm-arm64-Darwin-work.config.system.build.toplevel
+            install_options: ""
           - name: darwin-beleap-m1air
             runner: macos-latest
             flake_attr: .#darwinConfigurations.beleap-m1air.system
+            install_options: --no-daemon
           - name: darwin-csjang-m3pro
             runner: macos-latest
             flake_attr: .#darwinConfigurations.csjang-m3pro.system
+            install_options: --no-daemon
 
     steps:
       - name: Checkout
@@ -33,6 +37,7 @@ jobs:
         uses: cachix/install-nix-action@v27
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+          install_options: ${{ matrix.install_options }}
           extra_nix_config: |
             experimental-features = nix-command flakes
 


### PR DESCRIPTION
### Motivation
- Run Nix flake outputs for both NixOS and macOS (nix-darwin) in CI so build issues are caught early.
- Execute each flake output in parallel using a GitHub Actions matrix to speed feedback.
- Provide actionable failure information by posting build logs back to the PR or commit.
- Ensure flakes are built with experimental `nix-command` and `flakes` enabled for reproducible builds.

### Description
- Add `.github/workflows/build-flake.yml` which triggers on `push` and `pull_request` and runs a matrix job for multiple flake outputs.
- Matrix entries include NixOS and Darwin targets and provide `flake_attr` values used by `nix build` to build specific outputs.
- Steps perform `actions/checkout@v4`, install Nix via `cachix/install-nix-action@v27` with `experimental-features = nix-command flakes`, run `nix build "${{ matrix.flake_attr }}"` and capture output to `build.log` while recording the exit code to `GITHUB_OUTPUT`.
- On failure the workflow uses `actions/github-script@v7` to post the last ~65k characters of `build.log` as a comment on the PR or commit with the failing attribute name.

### Testing
- No automated tests were run in this change because the workflow itself executes in CI on `push`/`pull_request`.
- The workflow file was added and committed successfully to the branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963af320d648324a7f97c56fa83e060)