### PR TITLE
Disable Firefox built-in password manager and save prompts

### DIFF
--- a/config/recipe/firefox/default.nix
+++ b/config/recipe/firefox/default.nix
@@ -12,7 +12,7 @@ _: {
           NoDefaultBookmarks = true;
           OfferToSaveLogins = false;
           OfferToSaveLoginsDefault = false;
-          PasswordManagerEnabled = true;
+          PasswordManagerEnabled = false;
           FirefoxHome = {
             Search = true;
             Pocket = false;
@@ -48,6 +48,11 @@ _: {
               "sidebar.verticalTabs.dragToPinPromo.dismissed" = true;
 
               "app.update.auto" = false;
+
+              "signon.rememberSignons" = false;
+              "signon.autofillForms" = false;
+              "signon.generation.enabled" = false;
+              "signon.management.page.breach-alerts.enabled" = false;
             };
             extensions.packages = with pkgs.nur.repos.rycee.firefox-addons; [
               sidebery

--- a/journal/2026-04-20/disable-firefox-password-manager-prompts.md
+++ b/journal/2026-04-20/disable-firefox-password-manager-prompts.md
@@ -1,0 +1,4 @@
+- Updated Firefox policy config to fully disable built-in password manager behavior.
+- Set `PasswordManagerEnabled = false` and kept login-save prompts disabled via `OfferToSaveLogins` policies.
+- Added profile prefs to disable saving, autofill, password generation, and breach alerts for Firefox-managed credentials.
+- Context: user uses 1Password and wants all Firefox password-manager prompts/features off.


### PR DESCRIPTION
### Motivation
- Prevent Firefox from offering to save or autofill passwords because the user uses 1Password and doesn't want Firefox password-manager prompts or features active.

### Description
- Set the Firefox policy `PasswordManagerEnabled = false` and keep `OfferToSaveLogins` / `OfferToSaveLoginsDefault` disabled to stop save prompts at the policy level.
- Added profile preferences to fully disable built-in password features by setting `signon.rememberSignons = false`, `signon.autofillForms = false`, `signon.generation.enabled = false`, and `signon.management.page.breach-alerts.enabled = false` in `config/recipe/firefox/default.nix`.
- Added a journal entry at `journal/2026-04-20/disable-firefox-password-manager-prompts.md` documenting the change.

### Testing
- Ran `nix-instantiate --parse config/recipe/firefox/default.nix`, which failed because `nix-instantiate` is not available in this environment (expected failure).
- Verified repository state with `git status --short` and committed the changes, leaving the working tree clean (command succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58a4312308324ae276c3d573621e1)