### PR TITLE
Tidy lib/mkSystem.nix input destructuring

### DIFF
--- a/journal/2026-05-04/fix-mksystem-nix-darwin-attr-access.md
+++ b/journal/2026-05-04/fix-mksystem-nix-darwin-attr-access.md
@@ -1,0 +1,14 @@
+# Fix `lib/mkSystem.nix` nix-darwin attribute access regression
+
+- Follow-up for CI failure after input destructuring tidy.
+- Failure observed in CI:
+  - `error: attribute 'nix-darwin' missing`
+  - at `lib/mkSystem.nix` Darwin configuration construction.
+- Root cause: hyphenated flake input keys cannot be accessed via dotted syntax as `inputs.nix-darwin`; this does not resolve the intended `"nix-darwin"` attribute.
+- Fix: use quoted attribute access `inputs."nix-darwin".lib.darwinSystem`.
+
+## Validation
+
+- Local command attempted for parity with CI:
+  - `nix build .#darwinConfigurations.beleap-m1air.system --accept-flake-config --no-link --print-out-paths`
+- This environment does not provide `nix` (`nix: command not found`), so build validation remains for CI.

--- a/journal/2026-05-04/tidy-mksystem-input-destructuring.md
+++ b/journal/2026-05-04/tidy-mksystem-input-destructuring.md
@@ -1,0 +1,9 @@
+# Tidy `lib/mkSystem.nix` input destructuring
+
+- User request: "정리할만한거 있으면 찾아서 정리해봐".
+- Applied a tidy-first cleanup in `lib/mkSystem.nix` by narrowing the argument destructuring to only the fields actually used (`lib`, `metadata`, `recipes`) and replacing the rest with `...`.
+- Motivation: remove dead/unused parameter bindings and reduce noise while preserving behavior.
+
+## Validation
+
+- Attempted to run `nix run nixpkgs#deadnix -- .`, but this environment does not have `nix` installed (`nix: command not found`).

--- a/lib/mkSystem.nix
+++ b/lib/mkSystem.nix
@@ -15,7 +15,7 @@ in {
     };
   };
   darwinConfigurations = lib.optionalAttrs (metadata.distribution == "macos") {
-    "${metadata.name}" = inputs.nix-darwin.lib.darwinSystem {
+    "${metadata.name}" = inputs."nix-darwin".lib.darwinSystem {
       inherit specialArgs modules;
     };
   };

--- a/lib/mkSystem.nix
+++ b/lib/mkSystem.nix
@@ -2,16 +2,7 @@ inputs @ {
   lib,
   metadata,
   recipes,
-  nixpkgs,
-  nixpkgs-unstable,
-  nix-darwin,
-  home-manager,
-  nur,
-  agenix,
-  llm-agents,
-  mac-app-util,
-  beleap-overlay,
-  direnv-overlay,
+  ...
 }: let
   # TODO: we could remove metadata from specialArgs after migration to configs finishes
   specialArgs = {inherit inputs metadata;};


### PR DESCRIPTION
### Motivation
- Remove dead/unused input bindings in `lib/mkSystem.nix` to reduce noise and avoid static-check warnings while preserving behavior.

### Description
- Replace the explicit input list with `inputs @ { lib, metadata, recipes, ... }` in `lib/mkSystem.nix`, keep `specialArgs = { inherit inputs metadata; }` behavior, and add `journal/2026-05-04/tidy-mksystem-input-destructuring.md` documenting the cleanup.

### Testing
- Attempted to run `nix run nixpkgs#deadnix -- .` to confirm no unused-argument warnings, but the check could not run because `nix` is not available in this environment (`nix: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f61f50388324a02a1f2a3e0ead38)