### PR TITLE
Clarify guidance for including `journal/` entries in commits

### DIFF
--- a/files/AGENTS.md
+++ b/files/AGENTS.md
@@ -31,5 +31,9 @@ tools to resolve library id and get library docs without me having to explicitly
 
 - Record work history and any information useful for the next task in
   `journal/<date>/<appropriate_title>.md`.
+- Journal entries are working notes for continuity. When preparing a commit,
+  decide whether to include `journal/` entries based on relevance: include them
+  when they help explain or support the change, but do not treat them as
+  automatically required just because they were written.
 - Note: a coding agent is actively recording entries in `journal/`, so treat it as
   an existing source of task history and operational context.


### PR DESCRIPTION
### Motivation
- Clarify expectations for `journal/` working notes so authors only include them in commits when they add value rather than by default.

### Description
- Add guidance to the `Journal` section of `AGENTS.md` stating that `journal/` entries are working notes and should be included in commits only when relevant to explain or support the change.

### Testing
- No automated tests were applicable for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a265b1175708324aaf26fecbb05da17)