### PR TITLE
Use k9s for Kubernetes UI

### DIFF
--- a/config/recipe/kubernetes/default.nix
+++ b/config/recipe/kubernetes/default.nix
@@ -16,12 +16,12 @@ _: {
           kubectl-check
           kubernetes-helm
           kind
-          kdash
+          k9s
         ];
 
         home.shellAliases = {
           k = "kubectl-check";
-          ku = "kdash";
+          ku = "k9s";
         };
       }
     )

--- a/journal/2026-06-23/use-k9s-instead-of-kdash.md
+++ b/journal/2026-06-23/use-k9s-instead-of-kdash.md
@@ -1,0 +1,5 @@
+# Use k9s instead of kdash
+
+- Replaced the Kubernetes recipe package from `kdash` to `k9s`.
+- Updated the `ku` shell alias to launch `k9s`.
+- Attempted formatter checks, but this container does not have `nix` or `nixfmt` available.


### PR DESCRIPTION
### Motivation
- Switch the Kubernetes TUI from `kdash` to `k9s`, update the `ku` shell alias accordingly, and record the change in the journal.

### Description
- Replace `kdash` with `k9s` in `home.packages` and update `home.shellAliases.ku` to `k9s` in `config/recipe/kubernetes/default.nix`, and add `journal/2026-06-23/use-k9s-instead-of-kdash.md` documenting the change.

### Testing
- Attempted format/validation checks with `nixfmt --check config/recipe/kubernetes/default.nix` and `nix run nixpkgs#alejandra -- --check config/recipe/kubernetes/default.nix journal/2026-06-23/use-k9s-instead-of-kdash.md`, but both failed because `nix`/`nixfmt` are not available in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3acf30c2d88324b16371959d8e565a)