### PR TITLE
Enable opencode LSP

### DIFF
--- a/config/recipe/opencode/default.nix
+++ b/config/recipe/opencode/default.nix
@@ -41,6 +41,7 @@
           settings = {
             "$schema" = "https://opencode.ai/config.json";
             model = "openai/gpt-5.5";
+            lsp = true;
             instructions = [
               "${config.home.homeDirectory}/.config/opencode/AGENTS.md"
             ];

--- a/journal/2026-07-08/enable-opencode-lsp.md
+++ b/journal/2026-07-08/enable-opencode-lsp.md
@@ -1,0 +1,10 @@
+# Enable opencode LSP
+
+## Change
+- Enabled opencode's built-in LSP support by setting `programs.opencode.settings.lsp = true` in `config/recipe/opencode/default.nix`.
+
+## Notes
+- OpenCode documentation says omitting `lsp` leaves LSP disabled, while `lsp = true` enables all built-in LSP servers.
+
+## Validation
+- Attempted `nix-instantiate --parse config/recipe/opencode/default.nix`, but validation could not run because `nix-instantiate` is not installed in this environment.


### PR DESCRIPTION
### Motivation
- Enable opencode's built-in LSP support so the `opencode` program can provide language-server features from the user configuration.

### Description
- Set `programs.opencode.settings.lsp = true` in `config/recipe/opencode/default.nix` and add `journal/2026-07-08/enable-opencode-lsp.md` documenting the change and the validation limitation.

### Testing
- Attempted `nix-instantiate --parse config/recipe/opencode/default.nix` but validation could not run because `nix-instantiate` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e02c15ec88324955fc68bcde20f2d)