### PR TITLE
Match WezTerm tab bar font

### DIFF
--- a/config/recipe/wezterm/wezterm.lua
+++ b/config/recipe/wezterm/wezterm.lua
@@ -1,12 +1,16 @@
 local wezterm = require 'wezterm'
 local act = wezterm.action
 local config = wezterm.config_builder()
+local terminal_font = wezterm.font 'CaskaydiaCove Nerd Font Mono'
 
 config.default_prog = { '@zsh@', '-l' }
 config.default_workspace = 'sp'
 
 config.color_scheme = 'Gruvbox dark, medium (base16)'
-config.font = wezterm.font 'CaskaydiaCove Nerd Font Mono'
+config.font = terminal_font
+config.window_frame = {
+  font = terminal_font,
+}
 config.font_size = 16
 config.window_background_opacity = 0.8
 config.window_decorations = 'RESIZE'

--- a/journal/2026-07-09/match-wezterm-tab-bar-font.md
+++ b/journal/2026-07-09/match-wezterm-tab-bar-font.md
@@ -1,0 +1,4 @@
+# Match WezTerm tab bar font
+
+- Introduced a shared `terminal_font` value in the WezTerm Lua configuration.
+- Reused that font for both `config.font` and `config.window_frame.font` so the tab bar uses the same font as terminal panes.


### PR DESCRIPTION
### Motivation
- Make the WezTerm tab bar text use the same font as the terminal panes so UI typography is consistent.

### Description
- Define a shared `terminal_font` value in `config/recipe/wezterm/wezterm.lua` and assign it to `config.font`.
- Reuse the same `terminal_font` for `config.window_frame.font` so the tab bar uses the identical font.
- Add a short journal entry at `journal/2026-07-09/match-wezterm-tab-bar-font.md` describing the change.

### Testing
- Attempted `nix flake check --no-build`, but it was not run because `nix` is not available in the environment.
- Attempted `luac -p config/recipe/wezterm/wezterm.lua`, but it was not run because `luac` is not available in the environment.
- No automated configuration or syntax checks were executed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ef70f85ec832488c3af7ae831d7ef)