### PR TITLE
Add Pi extension to emit OSC 9 and OSC 777 from ctx.ui.notify

### DIFF
--- a/.journal/2026-07-15/pi-notify-osc-hook.md
+++ b/.journal/2026-07-15/pi-notify-osc-hook.md
@@ -1,0 +1,15 @@
+# Pi ctx.ui.notify OSC hook
+
+Added a declarative Pi extension at `config/recipe/pi/notify-osc.ts` and linked it to
+`~/.pi/agent/extensions/notify-osc.ts` via Home Manager.
+
+The extension patches `ctx.ui.notify` during `session_start` and adds a
+`/notify-osc-test` command. Every `ctx.ui.notify(message, level)` call now keeps the
+normal Pi notification behavior and also writes both terminal notification escape
+sequences in one stdout write:
+
+- OSC 9: `ESC ] 9 ; message BEL`
+- OSC 777: `ESC ] 777 ; notify ; title ; message BEL`
+
+OSC fields are sanitized to remove control characters and semicolons so malformed
+notification payloads are not emitted.

--- a/config/recipe/pi/default.nix
+++ b/config/recipe/pi/default.nix
@@ -59,6 +59,7 @@
               ];
             };
             ".pi/agent/sandbox.json".source = ./sandbox.json;
+            ".pi/agent/extensions/notify-osc.ts".source = ./notify-osc.ts;
             ".pi/agent/themes/gruvbox.json".source = ./gruvbox.json;
           };
         };

--- a/config/recipe/pi/notify-osc.ts
+++ b/config/recipe/pi/notify-osc.ts
@@ -1,0 +1,64 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+const PATCHED_NOTIFY = Symbol.for("beleap.notify-osc.patched");
+const OSC = "\x1b]";
+const BEL = "\x07";
+
+type NotifyLevel = "info" | "warning" | "error";
+type NotifyFn = (message: string, level?: NotifyLevel) => void;
+type PatchableUi = {
+  notify: NotifyFn;
+  [PATCHED_NOTIFY]?: boolean;
+};
+
+function sanitizeOscField(value: string): string {
+  return value.replace(/[\x00-\x1f\x7f;]/g, " ").trim();
+}
+
+function notificationTitle(level: NotifyLevel | undefined): string {
+  switch (level) {
+    case "warning":
+      return "Pi warning";
+    case "error":
+      return "Pi error";
+    default:
+      return "Pi";
+  }
+}
+
+function oscNotifications(message: string, level: NotifyLevel | undefined): string {
+  const body = sanitizeOscField(message);
+  const title = sanitizeOscField(notificationTitle(level));
+
+  return `${OSC}9;${body}${BEL}${OSC}777;notify;${title};${body}${BEL}`;
+}
+
+function patchNotify(ctx: ExtensionContext): void {
+  const ui = ctx.ui as PatchableUi;
+
+  if (ui[PATCHED_NOTIFY]) {
+    return;
+  }
+
+  const originalNotify = ui.notify.bind(ui);
+
+  ui.notify = (message: string, level?: NotifyLevel) => {
+    originalNotify(message, level);
+    process.stdout.write(oscNotifications(message, level));
+  };
+  ui[PATCHED_NOTIFY] = true;
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.on("session_start", async (_event, ctx) => {
+    patchNotify(ctx);
+  });
+
+  pi.registerCommand("notify-osc-test", {
+    description: "Send a test notification through ctx.ui.notify and OSC 9/777.",
+    handler: async (args, ctx) => {
+      patchNotify(ctx);
+      ctx.ui.notify(args.trim() || "Pi OSC notifications are enabled.", "info");
+    },
+  });
+}


### PR DESCRIPTION
### Motivation

- Provide terminal/desktop notification escape sequences alongside Pi's UI notifications so terminal emulators that support OSC 9 or OSC 777 can display desktop notifications when `ctx.ui.notify` is used.
- Keep existing Pi notification behavior while emitting both OSC 9 and OSC 777 in a single stdout write for atomic delivery.

### Description

- Add `config/recipe/pi/notify-osc.ts`, an extension that patches `ctx.ui.notify` to call the original notifier and then write both OSC 9 and OSC 777 sequences in one `stdout` write.
- Sanitize OSC fields to remove control characters and semicolons before embedding them into escape sequences to avoid malformed payloads.
- Patch is applied on `session_start` and the extension registers a `notify-osc-test` command that invokes `ctx.ui.notify` for manual testing.
- Wire the extension into the declarative Pi Home Manager setup by adding `".pi/agent/extensions/notify-osc.ts".source = ./notify-osc.ts;` in `config/recipe/pi/default.nix` and record implementation notes in `.journal/2026-07-15/pi-notify-osc-hook.md`.

### Testing

- Bundled the extension with `npx --yes esbuild config/recipe/pi/notify-osc.ts --bundle --platform=node --format=esm --external:@earendil-works/pi-coding-agent --outfile=/tmp/notify-osc.js`, which completed successfully and produced `/tmp/notify-osc.js`.
- Ran `git diff --check` to ensure no whitespace/patch issues and found no problems.
- Attempted to run Nix/Home-Manager checks via `alejandra --check config/recipe/pi/default.nix || nix run nixpkgs#alejandra -- --check config/recipe/pi/default.nix`, but `alejandra` and `nix` were unavailable in this environment so the declarative activation check could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57478260748324be15758f352a3dd8)