### PR TITLE
pi: emit only OSC 777 for notify to avoid duplicate desktop notifications

### DIFF
--- a/config/recipe/pi/notify-osc.ts
+++ b/config/recipe/pi/notify-osc.ts
@@ -26,11 +26,11 @@ function notificationTitle(level: NotifyLevel | undefined): string {
   }
 }
 
-function oscNotifications(message: string, level: NotifyLevel | undefined): string {
+function osc777Notification(message: string, level: NotifyLevel | undefined): string {
   const body = sanitizeOscField(message);
   const title = sanitizeOscField(notificationTitle(level));
 
-  return `${OSC}9;${body}${BEL}${OSC}777;notify;${title};${body}${BEL}`;
+  return `${OSC}777;notify;${title};${body}${BEL}`;
 }
 
 function patchNotify(ctx: ExtensionContext): void {
@@ -44,7 +44,7 @@ function patchNotify(ctx: ExtensionContext): void {
 
   ui.notify = (message: string, level?: NotifyLevel) => {
     originalNotify(message, level);
-    process.stdout.write(oscNotifications(message, level));
+    process.stdout.write(osc777Notification(message, level));
   };
   ui[PATCHED_NOTIFY] = true;
 }
@@ -55,7 +55,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.registerCommand("notify-osc-test", {
-    description: "Send a test notification through ctx.ui.notify and OSC 9/777.",
+    description: "Send a test notification through ctx.ui.notify and OSC 777.",
     handler: async (args, ctx) => {
       patchNotify(ctx);
       ctx.ui.notify(args.trim() || "Pi OSC notifications are enabled.", "info");

--- a/journal/2026-07-15/fix-pi-osc-notify-duplicate.md
+++ b/journal/2026-07-15/fix-pi-osc-notify-duplicate.md
@@ -1,0 +1,11 @@
+# Fix Pi OSC notify duplicate notifications
+
+Changed `config/recipe/pi/notify-osc.ts` to emit only OSC 777 for terminal
+notifications instead of both OSC 9 and OSC 777. Some terminals handle both
+protocols and produce two desktop notifications for a single `ctx.ui.notify`
+call when both sequences are written.
+
+OSC 777 is preferred for this setup because it keeps the notification title
+separate from the body, including the warning/error title mapping.
+
+Also updated the `/notify-osc-test` command description to mention OSC 777 only.


### PR DESCRIPTION
### Motivation
- Prevent terminals that support both OSC 9 and OSC 777 from producing duplicate desktop notifications by only emitting the OSC 777 sequence which keeps title and body separated.

### Description
- Replace the previous OSC 9+777 output with a single OSC 777 notification by renaming `oscNotifications` to `osc777Notification` and returning only the `OSC 777` sequence, update `process.stdout.write` to use the new function, and update the `/notify-osc-test` command description accordingly; also add a journal entry documenting the change.

### Testing
- Ran TypeScript type-check and basic linting (`tsc` and linter) against the modified files and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a574a0590cc8324b3936e44e964dcba)