### PR TITLE
Add ayghri/i-have-adhd to Pi declarative package list

### DIFF
--- a/config/recipe/pi/default.nix
+++ b/config/recipe/pi/default.nix
@@ -61,6 +61,7 @@
                 "openrouter/z-ai/glm-5.2"
               ];
               packages = [
+                "https://github.com/ayghri/i-have-adhd"
                 "npm:@upstash/context7-pi@0.1.1"
                 "npm:pi-mcp-adapter@2.11.0"
                 "npm:pi-notify@1.4.0"

--- a/journal/2026-07-20/add-i-have-adhd-to-pi.md
+++ b/journal/2026-07-20/add-i-have-adhd-to-pi.md
@@ -1,0 +1,10 @@
+# Add i-have-adhd to Pi
+
+Added `https://github.com/ayghri/i-have-adhd` to Pi's declarative global
+package list. Pi will clone the repository and discover its conventional
+`skills/i-have-adhd/SKILL.md` resource, making the skill available without a
+mutable `pi install` change.
+
+Verification: `git diff --check` passes. The environment does not provide the
+`alejandra` or `nix` executables, so formatting and Home Manager evaluation
+could not be run locally.


### PR DESCRIPTION
### Motivation

- Make the `i-have-adhd` skill available to Pi via the declarative Home Manager `settings.json` so the repository is discovered and usable without a manual `pi install`.

### Description

- Add the GitHub repository URL `https://github.com/ayghri/i-have-adhd` to the `packages` array in `config/recipe/pi/default.nix` so Pi will clone and load the package. 
- Add a work journal entry at `journal/2026-07-20/add-i-have-adhd-to-pi.md` documenting the change and local verification limitations.

### Testing

- Ran `git diff --check` which passed and created a commit containing the two file changes. 
- Verified the edited `settings.json` entry is present via a local `git diff` and inspected the committed file; `git status` shows a clean working tree. 
- `alejandra --check` and `nix` evaluation were not run because the environment does not provide the `alejandra` or `nix` executables, and this limitation is recorded in the journal.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ddbf43bc0832496893bed29341a04)