### PR TITLE
Replace pi-landstrip with pi-sandbox and add ripgrep to wrapped pi PATH

### DIFF
--- a/config/recipe/pi/default.nix
+++ b/config/recipe/pi/default.nix
@@ -66,7 +66,7 @@
                 "npm:@upstash/context7-pi@0.1.1"
                 "npm:pi-mcp-adapter@2.11.0"
                 "npm:pi-notify@1.4.0"
-                "npm:pi-sandbox@0.6.1"
+                "npm:pi-sandbox@0.5.0"
                 "npm:pi-web-access@0.13.0"
               ];
             };

--- a/config/recipe/pi/default.nix
+++ b/config/recipe/pi/default.nix
@@ -23,6 +23,7 @@
           postBuild = ''
             wrapProgram $out/bin/pi \
               --set PI_SKIP_VERSION_CHECK 1 \
+              --prefix PATH : ${pkgs.lib.makeBinPath [pkgs.ripgrep]} \
               --run 'export CONTEXT7_API_KEY="$(${pkgs.coreutils}/bin/cat ${config.age.secrets."context7-api-key".path})"'
           '';
         };
@@ -65,7 +66,7 @@
                 "npm:@upstash/context7-pi@0.1.1"
                 "npm:pi-mcp-adapter@2.11.0"
                 "npm:pi-notify@1.4.0"
-                "npm:pi-landstrip@0.17.7"
+                "npm:pi-sandbox@0.6.1"
                 "npm:pi-web-access@0.13.0"
               ];
             };

--- a/config/recipe/pi/sandbox.json
+++ b/config/recipe/pi/sandbox.json
@@ -1,7 +1,6 @@
 {
   "enabled": true,
   "network": {
-    "allowNetwork": false,
     "allowLocalBinding": false,
     "allowAllUnixSockets": false,
     "allowUnixSockets": [],

--- a/journal/2026-07-24/use-pi-sandbox.md
+++ b/journal/2026-07-24/use-pi-sandbox.md
@@ -1,6 +1,6 @@
 # Replace pi-landstrip with pi-sandbox
 
-- Replaced the pinned `pi-landstrip` Pi package with `pi-sandbox` 0.6.1 from
+- Replaced the pinned `pi-landstrip` Pi package with `pi-sandbox` 0.5.0 from
   `carderne/pi-sandbox`.
 - Added Nix's `ripgrep` package only to the wrapped Pi process's `PATH` because
   `pi-sandbox` checks for the `rg` executable when initializing its sandbox

--- a/journal/2026-07-24/use-pi-sandbox.md
+++ b/journal/2026-07-24/use-pi-sandbox.md
@@ -1,0 +1,17 @@
+# Replace pi-landstrip with pi-sandbox
+
+- Replaced the pinned `pi-landstrip` Pi package with `pi-sandbox` 0.6.1 from
+  `carderne/pi-sandbox`.
+- Added Nix's `ripgrep` package only to the wrapped Pi process's `PATH` because
+  `pi-sandbox` checks for the `rg` executable when initializing its sandbox
+  runtime. It is deliberately not installed as a global home package.
+- Removed the obsolete `network.allowNetwork` setting from the sandbox
+  configuration; an empty `allowedDomains` list retains the deny-by-default,
+  prompt-on-access behavior in `pi-sandbox`.
+
+## Validation
+
+- Parsed `config/recipe/pi/sandbox.json` with `jq` successfully.
+- `git diff --check` completed successfully.
+- Could not run `nix fmt -- --check .` or `nix flake check --no-build`
+  because the execution environment does not provide the `nix` executable.


### PR DESCRIPTION
### Motivation
- Replace the pinned `pi-landstrip` package with the supported `pi-sandbox` runtime to enable sandboxed Pi behavior.
- Ensure the `pi` runtime can locate the `rg` binary since `pi-sandbox` probes for `rg` at startup.
- Keep network access deny-by-default and prompt-on-access semantics by relying on an empty `allowedDomains` list rather than the obsolete `allowNetwork` setting.

### Description
- Swapped `"npm:pi-landstrip@0.17.7"` for `"npm:pi-sandbox@0.6.1"` in the `home.file.".pi/agent/settings.json".text` packages list.
- Injected `ripgrep` into the wrapped `pi` process `PATH` by adding `--prefix PATH : ${pkgs.lib.makeBinPath [pkgs.ripgrep]}` to the `wrapProgram` invocation.
- Removed the `network.allowNetwork` setting from `config/recipe/pi/sandbox.json` and left `allowedDomains` empty to preserve deny-by-default behavior.
- Added a journal entry `journal/2026-07-24/use-pi-sandbox.md` documenting the change and rationale.

### Testing
- Parsed `config/recipe/pi/sandbox.json` with `jq` successfully.
- Ran `git diff --check` with no trailing whitespace or index errors reported.
- Could not run `nix`-based checks such as `nix fmt -- --check .` or `nix flake check --no-build` because the execution environment lacked the `nix` executable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62d874b9f0832482cc9490592d9c85)