### PR TITLE
Allow Context7 tools in Pi permission modes

### DIFF
--- a/config/recipe/pi/permission-mode.json
+++ b/config/recipe/pi/permission-mode.json
@@ -38,6 +38,11 @@
         "askOnBlockedHost": true
       },
       "permission": {
+        "tool": {
+          "*": "ask",
+          "resolve-library-id": "allow",
+          "query-docs": "allow"
+        },
         "path": {
           "*": "allow",
           ".env": "deny",
@@ -81,6 +86,11 @@
         "askOnBlockedHost": true
       },
       "permission": {
+        "tool": {
+          "*": "ask",
+          "resolve-library-id": "allow",
+          "query-docs": "allow"
+        },
         "path": {
           "*": "allow",
           ".env": "deny",
@@ -124,6 +134,11 @@
         "askOnBlockedHost": true
       },
       "permission": {
+        "tool": {
+          "*": "allow",
+          "resolve-library-id": "allow",
+          "query-docs": "allow"
+        },
         "path": {
           "*": "allow",
           ".env": "deny",

--- a/journal/2026-07-27/allow-context7-operations-in-pi.md
+++ b/journal/2026-07-27/allow-context7-operations-in-pi.md
@@ -1,0 +1,5 @@
+# Allow Context7 operations in Pi
+
+Configured Pi permission modes to allow both tools exposed by `@upstash/context7-pi`: `resolve-library-id` and `query-docs`. Default and Plan modes retain first-use prompts for unrelated extension tools, while Build retains its allow-all extension-tool policy.
+
+Validated the JSON syntax and the pinned `pi-permission-modes` 2.2.0 schema. Nix formatting and Home Manager evaluation could not run because this environment provides neither `alejandra` nor `nix`.


### PR DESCRIPTION
### Motivation

- Permit the Context7 MCP tools used by Pi to run without repeated approval prompts so Pi can call `resolve-library-id` and `query-docs` during normal code/config workflows.
- Keep conservative prompting for unrelated extension tools in interactive/default flows while preserving Build mode's existing allow-all behavior.

### Description

- Updated `config/recipe/pi/permission-mode.json` to add a `tool` policy entry in the `default` and `plan` modes that sets `"*": "ask"` and explicitly `"allow"`s `resolve-library-id` and `query-docs`.
- Updated `config/recipe/pi/permission-mode.json` to add a `tool` policy entry in the `build` mode that sets `"*": "allow"` and explicitly `"allow"`s `resolve-library-id` and `query-docs` (keeps Build's allow-all semantics).
- Added a brief journal entry at `journal/2026-07-27/allow-context7-operations-in-pi.md` documenting the change and validation notes.

### Testing

- Ran `jq empty config/recipe/pi/permission-mode.json` to validate JSON syntax and it succeeded.
- Validated the JSON against the pinned `pi-permission-modes` schema with `npx --yes ajv-cli@5.0.0 validate --spec=draft2020 -s <schema> -d config/recipe/pi/permission-mode.json` and it succeeded.
- Ran repository checks `git diff --cached --check` and commit-related checks which passed and produced a clean commit; Nix/Alejandra evaluations could not run in this environment because `nix` and `alejandra` are not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67dab067c48324bcfcd5376946ed8c)