### PR TITLE
Use stable python313Packages.mlx-vlm for beleap-macmini

### DIFF
--- a/config/recipe/beleap-macmini/default.nix
+++ b/config/recipe/beleap-macmini/default.nix
@@ -15,13 +15,13 @@ _: {
     ({pkgs, ...}: {
       home.packages = with pkgs; [
         isync
-        unstable.python313Packages.mlx-vlm
+        python313Packages.mlx-vlm
       ];
       launchd.agents = {
         ml-self-hosted = {
           enable = true;
           config = {
-            Program = "${pkgs.unstable.python313Packages.mlx-vlm}/bin/mlx_vlm.server";
+            Program = "${pkgs.python313Packages.mlx-vlm}/bin/mlx_vlm.server";
             ProgramArguments = [
               "--model"
               "mlx-community/gemma-4-e4b-it-mxfp4"

--- a/journal/2026-07-27/pin-mlx-vlm-nixpkgs.md
+++ b/journal/2026-07-27/pin-mlx-vlm-nixpkgs.md
@@ -1,0 +1,19 @@
+# Use stable nixpkgs for mlx-vlm
+
+GitHub Actions run 30226203684 failed only while building `beleap-macmini` after
+the automated lock update moved `nixpkgs-unstable` from
+`7525d999cd850b9a488817abc89c75dc733acf17` to
+`37bfb33419c6e367e8bb6f44041eaecf953b5236`. The other two Darwin hosts built
+successfully; `beleap-macmini` is the only host that includes `mlx-vlm`.
+
+`mlx-vlm` is available at the same version in the stable nixpkgs package set, so
+the Mac mini now uses `pkgs.python313Packages.mlx-vlm`. This isolates the package
+from broad `nixpkgs-unstable` lock updates without adding another pinned input or
+overlay attribute.
+
+Validation:
+
+- Nix evaluation resolved the stable package as `python3.13-mlx-vlm-0.4.4`.
+- Nix evaluation was attempted locally, but evaluating the full Darwin system
+  exceeded the Linux container's available memory. CI on an Apple runner remains
+  the authoritative full build check.


### PR DESCRIPTION
### Motivation

- A GitHub Actions run failed when `nixpkgs-unstable` moved versions and the Darwin host `beleap-macmini` (which includes `mlx-vlm`) stopped building.
- The intent is to isolate `mlx-vlm` from broad `nixpkgs-unstable` lock updates by using the same package from the stable package set instead of the `unstable` attribute.

### Description

- Replaced references to `unstable.python313Packages.mlx-vlm` with `python313Packages.mlx-vlm` in `config/recipe/beleap-macmini/default.nix` to use the stable `nixpkgs` package set.
- Updated the `launchd` `Program` path to point at the stable package: `"${pkgs.python313Packages.mlx-vlm}/bin/mlx_vlm.server"`.
- Added `journal/2026-07-27/pin-mlx-vlm-nixpkgs.md` documenting the failure, rationale, and validation steps for the change.

### Testing

- Nix evaluation resolved the stable package as `python3.13-mlx-vlm-0.4.4` when tested locally and succeeded for package resolution. 
- The full Darwin system evaluation exceeded the Linux container's memory when attempted locally, so a complete Apple-runner CI build is required as the authoritative check. 
- Note that the original GitHub Actions run failed only for `beleap-macmini` while other Darwin hosts built successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67e95ec3c88324a344ba4d56c1d3c0)