### PR TITLE
Allow Context7 skill activation without approval

### DIFF
--- a/config/recipe/pi/permission-mode.json
+++ b/config/recipe/pi/permission-mode.json
@@ -43,6 +43,10 @@
           "resolve-library-id": "allow",
           "query-docs": "allow"
         },
+        "skill": {
+          "*": "ask",
+          "context7-docs": "allow"
+        },
         "path": {
           "*": "allow",
           ".env": "deny",
@@ -91,6 +95,10 @@
           "resolve-library-id": "allow",
           "query-docs": "allow"
         },
+        "skill": {
+          "*": "ask",
+          "context7-docs": "allow"
+        },
         "path": {
           "*": "allow",
           ".env": "deny",
@@ -138,6 +146,10 @@
           "*": "allow",
           "resolve-library-id": "allow",
           "query-docs": "allow"
+        },
+        "skill": {
+          "*": "allow",
+          "context7-docs": "allow"
         },
         "path": {
           "*": "allow",

--- a/journal/2026-07-27/allow-context7-operations-in-pi.md
+++ b/journal/2026-07-27/allow-context7-operations-in-pi.md
@@ -1,5 +1,5 @@
 # Allow Context7 operations in Pi
 
-Configured Pi permission modes to allow both tools exposed by `@upstash/context7-pi`: `resolve-library-id` and `query-docs`. Default and Plan modes retain first-use prompts for unrelated extension tools, while Build retains its allow-all extension-tool policy.
+Configured Pi permission modes to allow the `context7-docs` skill and both tools exposed by `@upstash/context7-pi`: `resolve-library-id` and `query-docs`. This prevents the skill activation that precedes the tool calls from prompting for approval. Default and Plan modes retain first-use prompts for unrelated skills and extension tools, while Build retains its allow-all policies.
 
-Validated the JSON syntax and the pinned `pi-permission-modes` 2.2.0 schema. Nix formatting and Home Manager evaluation could not run because this environment provides neither `alejandra` nor `nix`.
+Validated the JSON syntax and the pinned `pi-permission-modes` 2.2.0 schema. The first schema-validation attempt could not run because Python's `jsonschema` module is unavailable; validation was rerun successfully with `ajv-cli`. Nix formatting and Home Manager evaluation could not run because this environment provides neither `alejandra` nor `nix`.


### PR DESCRIPTION
### Motivation

- Prevent spurious approval prompts when the Context7 extension activates its `context7-docs` skill so the tools it calls can run smoothly in Pi sessions.
- Keep default safety behavior for unrelated skills and tools by only granting a targeted exception for the Context7 workflow.

### Description

- Added a `skill` permission block that allows the `context7-docs` skill in `Default`, `Plan`, and `Build` modes inside `config/recipe/pi/permission-mode.json` so skill activation no longer prompts for approval. 
- Preserved the existing `tool` allow rules for the Context7 tools (`resolve-library-id` and `query-docs`) and kept Build mode’s broad allow policy unchanged. 
- Updated `journal/2026-07-27/allow-context7-operations-in-pi.md` to document the change, the validation steps taken, and environment limitations.

### Testing

- Ran `python3 -m json.tool config/recipe/pi/permission-mode.json` and it succeeded. 
- Validated the instance against the pinned v2.2.0 schema using `npx --yes ajv-cli@5 validate --spec=draft2020 -s <schema> -d config/recipe/pi/permission-mode.json` and it succeeded. 
- Ran `git diff --check` and basic whitespace/diff checks passed. 
- Noted environment limitations: Python’s `jsonschema` module was unavailable (initial attempt failed), and `nix`/`alejandra` are not installed so Nix formatting and Home Manager evaluation could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67ea0185208324b06914b414999edb)