### PR TITLE
Use GPT Luna with max thinking in Pi

### DIFF
--- a/config/recipe/pi/default.nix
+++ b/config/recipe/pi/default.nix
@@ -48,8 +48,8 @@
             ".pi/agent/AGENTS.md".source = ../../../files/AGENTS.md;
             ".pi/agent/settings.json".text = builtins.toJSON {
               defaultProvider = "openai-codex";
-              defaultModel = "gpt-5.6-sol";
-              defaultThinkingLevel = "medium";
+              defaultModel = "gpt-5.6-luna";
+              defaultThinkingLevel = "max";
               defaultProjectTrust = "ask";
               enableInstallTelemetry = false;
               theme = "gruvbox";

--- a/journal/2026-08-03/use-gpt-luna-with-max-thinking-in-pi.md
+++ b/journal/2026-08-03/use-gpt-luna-with-max-thinking-in-pi.md
@@ -1,0 +1,8 @@
+# Use GPT Luna with max thinking in Pi
+
+Changed Pi's declarative settings to start new sessions with `gpt-5.6-luna`
+and the `max` thinking level. Luna was already included in the enabled model
+list, so no model availability change was necessary.
+
+Verification: `git diff --check` passes. The environment does not provide the
+`nix` executable, so the repository's flake check could not be run locally.


### PR DESCRIPTION
### Motivation
- Start Pi sessions with `gpt-5.6-luna` at the highest reasoning setting so new sessions use the Luna model and maximum thinking level by default.

### Description
- Updated `config/recipe/pi/default.nix` to set `defaultModel = "gpt-5.6-luna"` and `defaultThinkingLevel = "max"` and left the enabled model list unchanged.
- Added `journal/2026-08-03/use-gpt-luna-with-max-thinking-in-pi.md` to document the change and local verification limitations.

### Testing
- Ran `git diff --check`, which passed.
- Executed Python assertions that verified the `defaultModel`, `defaultThinkingLevel`, and presence of `"gpt-5.6-luna"` in the enabled models, which succeeded.
- `nix flake check` was not run because the `nix` executable is unavailable in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7022822c088324b56dea2228d748f5)