### PR TITLE
Make journal entries append-only

### DIFF
--- a/files/AGENTS.md
+++ b/files/AGENTS.md
@@ -30,6 +30,9 @@ tools to resolve library id and get library docs without me having to explicitly
 # Journal
 
 - Record non-trivial work in `.journal/<date>/<appropriate_title>.md`.
+- Treat journal entries as append-only: append new information to an existing entry
+  instead of rewriting or deleting its prior contents. Record corrections as new
+  notes so the original history remains visible.
 - Include, when applicable:
   - outcome and significant changes;
   - validation performed, including failures or blocked checks;

--- a/journal/2026-08-03/make-journal-append-only.md
+++ b/journal/2026-08-03/make-journal-append-only.md
@@ -1,0 +1,8 @@
+# Make journal entries append-only
+
+- Updated `files/AGENTS.md` to require appending to existing journal entries rather
+  than rewriting or deleting their prior contents.
+- Clarified that corrections should be recorded as new notes so the original work
+  history remains visible.
+- Validation: reviewed the focused diff and checked the updated Markdown for
+  whitespace errors.


### PR DESCRIPTION
### Motivation

- Preserve historical journal context by preventing rewrites or deletions of existing entries and requiring corrections to be appended as new notes.

### Description

- Added an append-only guidance line to `files/AGENTS.md` requiring new information to be appended to existing journal entries rather than rewriting or deleting prior contents.
- Added `journal/2026-08-03/make-journal-append-only.md` documenting the policy change and the validation performed.

### Testing

- Ran `git diff --check` to validate there are no whitespace or formatting errors and it succeeded.
- Reviewed a focused diff of `files/AGENTS.md` and checked the new Markdown file for whitespace/formatting issues, which passed.
- Verified repository working tree is clean after the change using a status check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70318e97c0832483107f5df0ddab2a)