### PR TITLE
Add pi-btw@0.4.1 to Pi agent packages

### DIFF
--- a/config/recipe/pi/default.nix
+++ b/config/recipe/pi/default.nix
@@ -65,6 +65,7 @@
               packages = [
                 "https://github.com/ayghri/i-have-adhd"
                 "npm:@upstash/context7-pi@0.1.1"
+                "npm:pi-btw@0.4.1"
                 "npm:pi-chrome@0.15.46"
                 "npm:pi-mcp-adapter@2.11.0"
                 "npm:pi-notify@1.4.0"

--- a/journal/2026-08-05/add-pi-btw.md
+++ b/journal/2026-08-05/add-pi-btw.md
@@ -1,0 +1,9 @@
+# Add pi-btw
+
+## Outcome
+
+Added the `pi-btw` package to the Pi agent package list so the `/btw` side-conversation extension is installed with the rest of the Pi extensions.
+
+## Validation
+
+- Checked the current npm version with `npm view pi-btw version description --json`; npm reported `0.4.1`.


### PR DESCRIPTION
### Motivation

- Add `pi-btw` so the Pi agent includes the `/btw` parallel side-conversation extension alongside the other Pi extensions.

### Description

- Inserted `"npm:pi-btw@0.4.1"` into the `packages` array in `config/recipe/pi/default.nix` and created `journal/2026-08-05/add-pi-btw.md` documenting the change.

### Testing

- Ran `npm view pi-btw version description --json` which succeeded and reported `0.4.1`.
- Attempted `nix fmt config/recipe/pi/default.nix journal/2026-08-05/add-pi-btw.md` but it failed because the `nix` executable is not available in the environment.
- Committed the changes with `git commit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72a4e724e48324b98205bc1b48ee70)