### PR TITLE
Route Chrome to Aerospace workspace 3

### DIFF
--- a/config/recipe/aerospace/default.nix
+++ b/config/recipe/aerospace/default.nix
@@ -113,7 +113,7 @@ _: {
                 "if" = {
                   app-id = "com.google.Chrome";
                 };
-                run = ["move-node-to-workspace 2"];
+                run = ["move-node-to-workspace 3"];
               }
               {
                 check-further-callbacks = false;

--- a/journal/2026-08-06/use-workspace-3-for-chrome.md
+++ b/journal/2026-08-06/use-workspace-3-for-chrome.md
@@ -1,0 +1,14 @@
+# Use Aerospace workspace 3 for Chrome
+
+## Summary
+
+- Changed the Aerospace Chrome window rule to move new Chrome windows to workspace 3 instead of workspace 2.
+
+## Files changed
+
+- `config/recipe/aerospace/default.nix`
+
+## Validation
+
+- Reviewed the focused diff and verified that only Chrome's target workspace changed.
+- Could not run the formatter or flake checks because `nix` is not installed in the environment.


### PR DESCRIPTION
### Motivation
- Place new Google Chrome windows on Aerospace workspace 3 instead of workspace 2 to match desired app workspace layout.

### Description
- Update `config/recipe/aerospace/default.nix` to change Chrome's rule to `run = ["move-node-to-workspace 3"]` (was workspace 2) and add a journal entry at `journal/2026-08-06/use-workspace-3-for-chrome.md` recording the change and rationale.

### Testing
- Ran `git diff --check` and a Python assertion that parsed `config/recipe/aerospace/default.nix` to verify the Chrome rule targets workspace `3`, both succeeded.
- Attempted `nix fmt -- --check` and `nix flake check` but they could not run because `nix` is not installed in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73eab056b08324a78de46495b57432)