### PR TITLE
Add KeepingYouAwake to all macOS hosts

### DIFF
--- a/config/recipe/macos/default.nix
+++ b/config/recipe/macos/default.nix
@@ -14,7 +14,7 @@
     inputs,
     ...
   }: {
-    environment.systemPackages = [];
+    environment.systemPackages = [pkgs.keeping-you-awake];
 
     # The platform the configuration will be used on.
     nixpkgs.hostPlatform = "aarch64-darwin";

--- a/journal/2026-08-11/add-keeping-you-awake-to-macos.md
+++ b/journal/2026-08-11/add-keeping-you-awake-to-macos.md
@@ -1,0 +1,8 @@
+# Add KeepingYouAwake to macOS
+
+Added `pkgs.keeping-you-awake` to the shared macOS system packages so every macOS host installs the application.
+
+## Validation
+
+- `git diff --check` passed.
+- Alejandra and `nix flake check --no-build` could not run because neither Alejandra nor Nix is installed in the environment.


### PR DESCRIPTION
### Motivation
- Ensure `KeepingYouAwake` is available on every macOS host by adding the package to the shared macOS `environment.systemPackages`.

### Description
- Update `config/recipe/macos/default.nix` to replace `environment.systemPackages = []` with `environment.systemPackages = [pkgs.keeping-you-awake];` and add `journal/2026-08-11/add-keeping-you-awake-to-macos.md` documenting the change.

### Testing
- Ran `git diff --check`, which passed.
- `alejandra --check` was not run because Alejandra is unavailable in the environment.
- `nix flake check --no-build` was not run because Nix is unavailable in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7aeb2e615483249a2dcaf6bc72bda5)